### PR TITLE
Don't break when a Brewfile contains `mas` or `whalebrew` lines

### DIFF
--- a/cmd/add.rb
+++ b/cmd/add.rb
@@ -55,10 +55,11 @@ module Homebrew
         parsed_entries = Bundle::Dsl.new(brewfile.read).entries
         bundle_taps, bundle_formulae, bundle_casks = [], [], []
         parsed_entries.each do |entry|
-            case entry.type # Could match nothing!!!
+            case entry.type
                 when :tap; bundle_taps
                 when :brew; bundle_formulae
                 when :cask; bundle_casks
+                else; next # Matches `mas` and `whalebrew`. This fixes issue #1.
             end << entry.name
         end
 


### PR DESCRIPTION
Fixes #1 by adding an `else; next` case in the `parsed_entries.each do |entry|` loop.

A huge thanks to @boldandbrad for bringing this issue to light.