### PR TITLE
Fix error caused by using `brew drop` with casks

### DIFF
--- a/cmd/drop.rb
+++ b/cmd/drop.rb
@@ -57,14 +57,14 @@ module Homebrew
         brews.each do |brew|
 
             # Get the corresponding reference list and terms for the given item.
-            current_bundle_list, brewfile_prefix_type, display_type = if brew.is_a?(Formula)
-                [bundle_formulae, "brew", "Formula"]
+            current_bundle_list, brewfile_prefix_type, display_type, resolved_brew_name = if brew.is_a?(Formula)
+                [bundle_formulae, "brew", "Formula", Formulary.resolve(brew.name)]
             else
-                [bundle_casks, "cask", "Cask"]
+                [bundle_casks, "cask", "Cask", Cask::CaskLoader.load(brew.token)]
             end
 
             # Check to see if the brew name (excluding tap) resolves to the full name (including tap).
-            brew_name_resolves_to_full_name = Formulary.resolve(brew.name).full_name == brew.full_name
+            brew_name_resolves_to_full_name = resolved_brew_name.full_name == brew.full_name
 
             # Drop the formula/cask from the file if it exists.
             unless current_bundle_list.include?(brew.full_name) || (brew_name_resolves_to_full_name && current_bundle_list.include?(brew.name))


### PR DESCRIPTION
Fixes #8 by using `Cask::CaskLoader.load(brew.token).full_name` to resolve the full name of a cask from it's short name (`brew.token`).

A huge thanks (again) to @boldandbrad for reporting this issue.