### PR TITLE
Fix: pass brewfile as path to Dsl.new instead of reading it.

### DIFF
--- a/cmd/add.rb
+++ b/cmd/add.rb
@@ -60,7 +60,7 @@ module Homebrew
         ohai "Using Brewfile at '#{brewfile}'" unless silent
 
         # Parse the Brewfile and create separate arrays for formulae, casks, and taps.
-        parsed_entries = Bundle::Dsl.new(brewfile.read).entries
+        parsed_entries = Bundle::Dsl.new(brewfile).entries
         bundle_taps, bundle_formulae, bundle_casks = [], [], []
         parsed_entries.each do |entry|
             case entry.type

--- a/cmd/drop.rb
+++ b/cmd/drop.rb
@@ -42,7 +42,7 @@ module Homebrew
         ohai "Using Brewfile at '#{brewfile}'" unless silent
 
         # Parse the Brewfile and create separate arrays for formulae, casks, and taps.
-        parsed_entries = Bundle::Dsl.new(brewfile.read).entries
+        parsed_entries = Bundle::Dsl.new(brewfile).entries
         bundle_taps, bundle_formulae, bundle_casks = [], [], []
         parsed_entries.each do |entry|
             case entry.type


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-bundle/pull/1365 changed Bundle::Dsl initializer to take a path instead of string input, so add/drop no longer need to call `#read`.